### PR TITLE
ci(package.json): remove ember-try from smoke testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ workflows:
 
   workflow-build-and-test:
     jobs:
-      - job-build-and-test:
+      - job-build-and-test
 
 jobs:
   job-build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ workflows:
   workflow-build-and-test:
     jobs:
       - job-build-and-test:
-          filters:
-            branches:
-              only:
-                - master
 
 jobs:
   job-build-and-test:

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
 	"hooks": {
-		"prepare-commit-msg": "exec < /dev/tty && npx git-cz --signoff --hook || true",
+		"prepare-commit-msg": "exec < /dev/tty && npx git-cz --hook --signoff",
 		"commit-msg": "npx commitlint -E HUSKY_GIT_PARAMS",
 		"pre-commit": "npx lint-staged",
 		"pre-push": "npx lint-staged"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"lint:hbs": "npx ember-template-lint .",
 		"lint:js": "npx eslint .",
 		"start": "ember serve",
-		"test": "npm-run-all --continue-on-error --serial lint:* test:*",
+		"test": "npm-run-all --continue-on-error --serial lint:* test:ember",
 		"test:ember": "npx ember test",
 		"test:ember-compatibility": "npx ember try:each",
 		"semantic-release": "semantic-release"
@@ -130,9 +130,6 @@
 	},
 	"ember-addon": {
 		"configPath": "tests/dummy/config"
-	},
-	"publishConfig": {
-		"access": "restricted"
 	},
 	"homepage": "https://twyr.github.io/twyr-patternfly"
 }


### PR DESCRIPTION
Removed ember-try from the build in CircleCI - we need only basic smoke testing scenarios to be
executed on each PR